### PR TITLE
RFC: Skip mounted detach

### DIFF
--- a/ksu-webui/src/index.js
+++ b/ksu-webui/src/index.js
@@ -42,7 +42,7 @@ async function main() {
 	const pkgs = await run("pm list packages");
 	if (pkgs === undefined) return;
 
-	const detached_list_out = await run("detach list");
+	const detached_list_out = await run("/data/adb/modules/zygisk-detach/system/bin/detach list");
 	if (detached_list_out === undefined) return;
 	const detached = detached_list_out.split('\n');
 
@@ -64,7 +64,7 @@ async function main() {
 
 	document.getElementById("detach").addEventListener('click', (e) => {
 		const detach_arg = detach_list.join(' ');
-		run(`detach detachall "${detach_arg}"`).then((out) => toast(out));
+		run(`/data/adb/modules/zygisk-detach/system/bin/detach detachall "${detach_arg}"`).then((out) => toast(out));
 	});
 }
 

--- a/magisk/customize.sh
+++ b/magisk/customize.sh
@@ -7,6 +7,16 @@ fi
 mv -f "$MODPATH/system/bin/detach-${ARCH}" "$MODPATH/system/bin/detach"
 rm "$MODPATH"/system/bin/detach-*
 
+# symlink detach to manager path
+# for ez termux usage
+manager_paths="/data/adb/ap/bin /data/adb/ksu/bin"
+for i in $manager_paths; do
+	if [ -d $i ] && [ ! -f $i/detach ]; then
+		echo "[+] creating symlink in $i"
+		ln -sf /data/adb/modules/zygisk-detach/system/bin/detach $i/detach
+	fi
+done
+
 # preserve detach.bin
 if [ -f "$NVBASE/modules/zygisk-detach/detach.bin" ]; then
 	ui_print "- Preserving existing detach.bin"

--- a/magisk/service.sh
+++ b/magisk/service.sh
@@ -1,3 +1,11 @@
 #!/system/bin/sh
 MODDIR=${0%/*}
 [ -f "$MODDIR/detach.txt" ] && "$MODDIR"/system/bin/detach serialize "$MODDIR/detach.txt" "$MODDIR/detach.bin"
+
+# yes we just create the symlink at every boot these tmpfs dirs 
+# magisk will add /debug_ramdisk, /sbin on $PATH
+[ -f /data/adb/magisk/magisk ] && {
+	[ -w /sbin ] && rwdir=/sbin
+	[ -w /debug_ramdisk ] && rwdir=/debug_ramdisk
+	ln -sf $MODDIR/system/bin/detach $rwdir/detach
+}

--- a/magisk/uninstall.sh
+++ b/magisk/uninstall.sh
@@ -1,0 +1,2 @@
+rm /data/adb/ap/bin/detach
+rm /data/adb/ksu/bin/detach


### PR DESCRIPTION
this removes the need for zygisk-detach to have a /system mount
this helps to cut down on root detections.

this method symlinks detach executable to root manager's $PATH
same method has been used on "bindhosts" where we needed to 
have skip_mount working even if we have an executable on $PATH