### PR TITLE
Prettier Name in Module Manager

### DIFF
--- a/magisk/module.prop
+++ b/magisk/module.prop
@@ -1,5 +1,5 @@
 id=zygisk-detach
-name=zygisk-detach
+name=Zygisk - Detach
 version=v1.20.0
 versionCode=27
 author=j-hc


### PR DESCRIPTION
This update standardizes the module name formatting in the module manager UI.

Most Zygisk modules follow a naming convention similar to `Zygisk - ModuleName`, and this change aligns the display name with that convention to improve consistency and user recognition.

No functional changes, this is purely aesthetic.